### PR TITLE
Fix OpenAPI schema generation around Albums

### DIFF
--- a/lib/pleroma/web/api_spec.ex
+++ b/lib/pleroma/web/api_spec.ex
@@ -141,6 +141,13 @@ defmodule Pleroma.Web.ApiSpec do
             ]
           },
           %{
+            "name" => "Albums",
+            "tags" => [
+              "Albums",
+              "Album content"
+            ]
+          },
+          %{
             "name" => "Miscellaneous",
             "tags" => [
               "Emoji packs",

--- a/lib/pleroma/web/api_spec/operations/artcafe_album_operation.ex
+++ b/lib/pleroma/web/api_spec/operations/artcafe_album_operation.ex
@@ -162,7 +162,7 @@ defmodule Pleroma.Web.ApiSpec.ArtcafeAlbumOperation do
 
   def get_items_operation do
     %Operation{
-      tags: ["Albums"],
+      tags: ["Album content"],
       summary: "Get activities in album",
       description: "Gets the activities in a given",
       operationId: "AlbumController.get_items",
@@ -183,7 +183,7 @@ defmodule Pleroma.Web.ApiSpec.ArtcafeAlbumOperation do
 
   def add_item_operation do
     %Operation{
-      tags: ["Albums"],
+      tags: ["Album content"],
       summary: "Add activity to album",
       description: "Adds the specified activity to an album owned by you",
       operationId: "AlbumController.add_item",
@@ -201,7 +201,7 @@ defmodule Pleroma.Web.ApiSpec.ArtcafeAlbumOperation do
 
   def remove_item_operation do
     %Operation{
-      tags: ["Albums"],
+      tags: ["Album content"],
       summary: "Add activity to album",
       description: "Adds the specified activity to an album owned by you",
       operationId: "AlbumController.remove_item",


### PR DESCRIPTION
The PR that added Albums (#1) introduced a bug that causes `mix pleroma.openapi_spec` to fail. This PR fixes this issue.